### PR TITLE
perf: Improve upload efficiency, fix JWT issue, enhance testing, and refine file creation response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.9.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.3
@@ -21,6 +22,7 @@ require (
 	github.com/bytedance/sonic v1.11.2 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
@@ -39,6 +41,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
-github.com/gin-contrib/cors v1.6.0 h1:0Z7D/bVhE6ja07lI8CTjTonp6SB07o8bNuFyRbsBUQg=
-github.com/gin-contrib/cors v1.6.0/go.mod h1:cI+h6iOAyxKRtUtC6iF/Si1KSFvGm/gK+kshxlCi8ro=
 github.com/gin-contrib/cors v1.7.0 h1:wZX2wuZ0o7rV2/1i7gb4Jn+gW7HBqaP91fizJkBUJOA=
 github.com/gin-contrib/cors v1.7.0/go.mod h1:cI+h6iOAyxKRtUtC6iF/Si1KSFvGm/gK+kshxlCi8ro=
 github.com/gin-contrib/gzip v0.0.6 h1:NjcunTcGAj5CO1gn4N8jHOSIeRFHIbn51z6K+xaN4d4=

--- a/middleware/auth_checker.go
+++ b/middleware/auth_checker.go
@@ -2,6 +2,7 @@
 package middleware
 
 import (
+	"github.com/vvbbnn00/goflet/config"
 	"net/http"
 	"net/url"
 	"strings"
@@ -24,6 +25,12 @@ const (
 // AuthChecker ensures the request is authenticated and authorized
 func AuthChecker() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Check if the JWT is enabled
+		if !*config.GofletCfg.JWTConfig.Enabled {
+			c.Next()
+			return
+		}
+
 		token := extractToken(c)
 		if token == "" {
 			unauthorized(c, "Missing token")

--- a/middleware/auth_checker.go
+++ b/middleware/auth_checker.go
@@ -2,10 +2,11 @@
 package middleware
 
 import (
-	"github.com/vvbbnn00/goflet/config"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/vvbbnn00/goflet/config"
 
 	"github.com/gin-gonic/gin"
 

--- a/route/api/action/base.go
+++ b/route/api/action/base.go
@@ -34,13 +34,13 @@ type CopyMoveFileRequest struct {
 // checkPath checks if the path is not empty
 func checkPath(path string, c *gin.Context) (*util.Path, error) {
 	if path == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Path is required"})
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Path is required"})
 		return nil, errors.New("Path is required")
 	}
 
 	pathData, err := util.ParsePath(path)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return nil, err
 	}
 
@@ -53,7 +53,7 @@ func preCheckForCopyMoveRoute(c *gin.Context) (*util.Path, *util.Path, bool) {
 	var req CopyMoveFileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		log.Debugf("Error binding request: %s", err.Error())
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
 		return nil, nil, false
 	}
 
@@ -71,13 +71,13 @@ func preCheckForCopyMoveRoute(c *gin.Context) (*util.Path, *util.Path, bool) {
 
 	// Check if the source and target paths are the same
 	if sourcePath.FsPath == targetPath.FsPath {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Source and target paths are the same"})
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Source and target paths are the same"})
 		return nil, nil, false
 	}
 
 	// Check if the source file exists
 	if !storage.FileExists(sourcePath.FsPath) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Source file not found"})
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "Source file not found"})
 		return nil, nil, false
 	}
 
@@ -87,13 +87,13 @@ func preCheckForCopyMoveRoute(c *gin.Context) (*util.Path, *util.Path, bool) {
 		default:
 			fallthrough
 		case OnConflictActionAbort:
-			c.JSON(http.StatusConflict, gin.H{"error": "File already exists"})
+			c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": "File already exists"})
 			return nil, nil, false
 		case OnConflictActionOverwrite:
 			// Delete the target file
 			err := storage.DeleteFile(targetPath.FsPath)
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Error deleting target file"})
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error deleting target file"})
 				return nil, nil, false
 			}
 		}

--- a/route/api/action/copy.go
+++ b/route/api/action/copy.go
@@ -43,7 +43,7 @@ func routeCopyFile(c *gin.Context) {
 	err := storage.CopyFile(sourcePath, targetPath)
 	if err != nil {
 		log.Debugf("Error copying file: %s", err.Error())
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error copying file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error copying file"})
 		return
 	}
 

--- a/route/api/action/create.go
+++ b/route/api/action/create.go
@@ -23,7 +23,7 @@ type CreateFileRequest struct {
 // @Accept       json
 // @Produce      json
 // @Param        body body CreateFileRequest true "Request body"
-// @Success      200  {object} string	"OK"
+// @Success      201  {object} string	"File created"
 // @Failure      400  {object} string	"Bad request"
 // @Failure      409  {object} string	"File exists"
 // @Failure      500  {object} string	"Internal server error"
@@ -68,5 +68,5 @@ func routeCreateFile(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "File created"})
+	c.JSON(http.StatusCreated, gin.H{"message": "File created"})
 }

--- a/route/api/action/create.go
+++ b/route/api/action/create.go
@@ -34,7 +34,7 @@ func routeCreateFile(c *gin.Context) {
 	var req CreateFileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		log.Debugf("Error binding request: %s", err.Error())
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
 		return
 	}
 
@@ -47,7 +47,7 @@ func routeCreateFile(c *gin.Context) {
 	// Check if the file already exists
 	if storage.FileExists(pathData.FsPath) {
 		log.Debugf("File already exists: %s", pathData.FsPath)
-		c.JSON(http.StatusConflict, gin.H{"error": "File already exists"})
+		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": "File already exists"})
 		return
 	}
 
@@ -64,7 +64,7 @@ func routeCreateFile(c *gin.Context) {
 	err = storage.CreateFile(pathData)
 	if err != nil {
 		log.Debugf("Error creating file: %s", err.Error())
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error creating file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error creating file"})
 		return
 	}
 

--- a/route/api/action/move.go
+++ b/route/api/action/move.go
@@ -43,7 +43,7 @@ func routeMoveFile(c *gin.Context) {
 	err := storage.MoveFile(sourcePath, targetPath)
 	if err != nil {
 		log.Debugf("Error moving file: %s", err.Error())
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error moving file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error moving file"})
 		return
 	}
 

--- a/route/api/image/route.go
+++ b/route/api/image/route.go
@@ -51,13 +51,13 @@ func routeGetImage(c *gin.Context) {
 	// Get the file info
 	fileInfo, err := storage.GetFileInfo(fsPath)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "File not found"})
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "File not found"})
 		return
 	}
 
 	// Check if the file is an image
 	if !fileInfo.IsImage() {
-		c.JSON(http.StatusNotFound, gin.H{"error": "File not found"})
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "File not found"})
 		return
 	}
 
@@ -65,7 +65,7 @@ func routeGetImage(c *gin.Context) {
 
 	// Check if the file is too large
 	if fileInfo.FileSize > config.GofletCfg.ImageConfig.MaxFileSize {
-		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "File too large"})
+		c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{"error": "File too large"})
 		return
 	}
 
@@ -93,7 +93,7 @@ func routeGetImage(c *gin.Context) {
 	// Get the file read stream
 	reader, err := storage.GetFileReader(fsPath)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error reading file"})
 		return
 	}
 	defer func() {
@@ -104,11 +104,11 @@ func routeGetImage(c *gin.Context) {
 
 	if err != nil {
 		if err.Error() == "image size is too large" {
-			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "Image size is too large"})
+			c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{"error": "Image size is too large"})
 			return
 		}
 		log.Warnf("Error processing image: %s", err.Error())
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error processing image"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error processing image"})
 		return
 	}
 

--- a/route/api/meta/route.go
+++ b/route/api/meta/route.go
@@ -42,7 +42,7 @@ func routeGetFileMeta(c *gin.Context) {
 	fileInfo, err := storage.GetFileInfo(fsPath)
 	if err != nil {
 		log.Debugf("Error getting file info: %s", err.Error())
-		c.JSON(http.StatusNotFound, gin.H{"error": "File not found"})
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "File not found"})
 		return
 	}
 

--- a/route/api/onlyoffice/route.go
+++ b/route/api/onlyoffice/route.go
@@ -49,27 +49,27 @@ func routeUpdateFile(c *gin.Context) {
 	o := onlyOfficeUpdateRequest{}
 	err := c.BindJSON(&o)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
 		return
 	}
 
 	// No need to update the file
 	if o.Status != 2 {
-		c.JSON(http.StatusOK, gin.H{"error": 0})
+		c.AbortWithStatusJSON(http.StatusOK, gin.H{"error": 0})
 		return
 	}
 
 	// Get the file info
 	_, err = storage.GetFileInfo(fsPath)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "File not found"})
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "File not found"})
 		return
 	}
 
 	// Get the file write stream
 	file, err := upload.GetTempFileWriteStream(relativePath)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error writing file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error writing file"})
 		return
 	}
 
@@ -77,7 +77,7 @@ func routeUpdateFile(c *gin.Context) {
 	resp, err := http.Get(o.URL)
 	if err != nil {
 		log.Warnf("Error downloading file: %s", err.Error())
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error downloading file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error downloading file"})
 		return
 	}
 	defer func() {
@@ -88,7 +88,7 @@ func routeUpdateFile(c *gin.Context) {
 	_, err = io.Copy(file, resp.Body)
 	if err != nil {
 		log.Warnf("Error writing downloaded file: %s", err.Error())
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error writing file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error writing file"})
 		return
 	}
 
@@ -100,7 +100,7 @@ func routeUpdateFile(c *gin.Context) {
 	if err != nil {
 		errStr := err.Error()
 		log.Warnf("Error completing file upload: %s", errStr)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error completing file upload"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error completing file upload"})
 		return
 	}
 

--- a/route/file/operation_download.go
+++ b/route/file/operation_download.go
@@ -43,7 +43,7 @@ func routeGetFile(c *gin.Context) {
 	fileInfo, err := storage.GetFileInfo(fsPath)
 	if err != nil {
 		log.Debugf("Error getting file info: %s", err.Error())
-		c.JSON(http.StatusNotFound, gin.H{"error": "File not found"})
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "File not found"})
 		return
 	}
 
@@ -64,7 +64,7 @@ func routeGetFile(c *gin.Context) {
 	file, err := storage.GetFileReader(fsPath)
 	if err != nil {
 		log.Warnf("Error getting file reader: %s", err.Error())
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error reading file"})
 		return
 	}
 	defer func(file *os.File) {
@@ -132,7 +132,7 @@ func handleRangeRequests(c *gin.Context, file *os.File, fileInfo *model.FileInfo
 
 	byteStart, byteEnd, err := util.HeaderParseRangeDownload(rangeHeader, fileInfo.FileSize)
 	if err != nil {
-		c.JSON(http.StatusRequestedRangeNotSatisfiable, gin.H{"error": err.Error()})
+		c.AbortWithStatusJSON(http.StatusRequestedRangeNotSatisfiable, gin.H{"error": err.Error()})
 		return
 	}
 	contentLength := byteEnd - byteStart + 1
@@ -142,7 +142,7 @@ func handleRangeRequests(c *gin.Context, file *os.File, fileInfo *model.FileInfo
 
 	if _, err := file.Seek(byteStart, io.SeekStart); err != nil {
 		log.Warnf("Error seeking file: %s", err.Error())
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error reading file"})
 		return
 	}
 

--- a/route/file/operation_other.go
+++ b/route/file/operation_other.go
@@ -35,12 +35,12 @@ func routePostFile(c *gin.Context) {
 
 	// If error is not nil and the error is "http: request body too large", return a 413 status code
 	if err != nil && err.Error() == "http: request body too large" {
-		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "File too large, please use PUT method to upload large files"})
+		c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{"error": "File too large, please use PUT method to upload large files"})
 		return
 	}
 	if err != nil {
 		log.Warnf("Error getting file: %s", err.Error())
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Bad request"})
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Bad request"})
 		return
 	}
 	// If the file is not nil, handle the single file upload
@@ -69,11 +69,11 @@ func routeDeleteFile(c *gin.Context) {
 	if err != nil {
 		errStr := err.Error()
 		if errStr == "file_not_found" {
-			c.JSON(http.StatusNotFound, gin.H{"error": "File not found"})
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "File not found"})
 			return
 		}
 		log.Warnf("Error deleting file: %s", errStr)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error deleting file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error deleting file"})
 		return
 	}
 
@@ -88,11 +88,11 @@ func handleSingleFileUpload(file *multipart.FileHeader, c *gin.Context) {
 	if err != nil {
 		errStr := err.Error()
 		if errStr == "directory_creation" {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Directory creation not allowed"})
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Directory creation not allowed"})
 			return
 		}
 		log.Warnf("Error getting write stream: %s", errStr)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error writing file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error writing file"})
 		return
 	}
 
@@ -100,7 +100,7 @@ func handleSingleFileUpload(file *multipart.FileHeader, c *gin.Context) {
 	fileReader, err := file.Open()
 	if err != nil {
 		log.Warnf("Error opening file: %s", err.Error())
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error reading file"})
 		return
 	}
 
@@ -108,7 +108,7 @@ func handleSingleFileUpload(file *multipart.FileHeader, c *gin.Context) {
 	_, err = io.Copy(writeStream, fileReader)
 	if err != nil {
 		log.Warnf("Error copying file: %s", err.Error())
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error writing file"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error writing file"})
 		return
 	}
 
@@ -124,15 +124,15 @@ func handleCompleteFileUpload(relativePath string, c *gin.Context) {
 	if err != nil {
 		errStr := err.Error()
 		if errStr == "file_uploading" {
-			c.JSON(http.StatusConflict, gin.H{"error": "The file completion is in progress"})
+			c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": "The file completion is in progress"})
 			return
 		}
 		if errStr == "file_not_found" {
-			c.JSON(http.StatusNotFound, gin.H{"error": "File not found or upload not started"})
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "File not found or upload not started"})
 			return
 		}
 		log.Warnf("Error completing file upload: %s", errStr)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error completing file upload"})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Error completing file upload"})
 		return
 	}
 

--- a/route/file/partical.go
+++ b/route/file/partical.go
@@ -1,10 +1,11 @@
 package file
 
 import (
-	"github.com/vvbbnn00/goflet/config"
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/vvbbnn00/goflet/config"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"

--- a/route/test/action_test.go
+++ b/route/test/action_test.go
@@ -1,0 +1,202 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vvbbnn00/goflet/route"
+)
+
+var (
+	sourcePath   = "/tmp/source.txt"
+	targetPath   = "/tmp/target.txt"
+	invalidPath  = "/tmp/invalid.txt"
+	imagePath    = "/tmp/image.jpg"
+	metaFilePath = "/tmp/meta.txt"
+	newFilePath  = "/tmp/newfile.txt"
+)
+
+// CopyMoveFileRequest is the request body for the copy/move file action
+type CopyMoveFileRequest struct {
+	OnConflict string `json:"onConflict"`
+	SourcePath string `json:"sourcePath"`
+	TargetPath string `json:"targetPath"`
+}
+
+// CreateFileRequest is the request body for the create file action
+type CreateFileRequest struct {
+	Path string `json:"path"`
+}
+
+func init() {
+	router = route.RegisterRoutes()
+}
+
+// prepareFileActions prepares the file actions for testing
+func TestPrepareFileActions(_ *testing.T) {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodDelete, "/file"+targetPath, nil)
+	router.ServeHTTP(w, req)
+	req, _ = http.NewRequest(http.MethodDelete, "/file"+invalidPath, nil)
+	router.ServeHTTP(w, req)
+	req, _ = http.NewRequest(http.MethodDelete, "/file"+newFilePath, nil)
+	router.ServeHTTP(w, req)
+
+	postUploadFile(sourcePath, gifData)
+	postUploadFile(imagePath, gifData)
+	postUploadFile(metaFilePath, gifData)
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+func postUploadFile(path string, data []byte) {
+	w := httptest.NewRecorder()
+	formData := new(bytes.Buffer)
+	writer := multipart.NewWriter(formData)
+	part, _ := writer.CreateFormFile("file", "test.txt")
+	_, err := part.Write(data)
+	if err != nil {
+		log.Fatalf("Failed to create %s\n", err.Error())
+	}
+	_ = writer.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, "/file"+path, formData)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	router.ServeHTTP(w, req)
+}
+
+func removeFile(path string) {
+	req, _ := http.NewRequest(http.MethodDelete, "/api/action/delete", bytes.NewReader([]byte(`{"path":"`+path+`"}`)))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+}
+
+func TestCopyFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		request        CopyMoveFileRequest
+		expectedStatus int
+	}{
+		{"Copy Existing File", CopyMoveFileRequest{OnConflict: "overwrite", SourcePath: sourcePath, TargetPath: targetPath}, http.StatusOK},
+		{"Copy Non-Existing Source", CopyMoveFileRequest{OnConflict: "overwrite", SourcePath: invalidPath, TargetPath: targetPath}, http.StatusNotFound},
+		{"Copy to Existing Target - Overwrite", CopyMoveFileRequest{OnConflict: "overwrite", SourcePath: sourcePath, TargetPath: targetPath}, http.StatusOK},
+		{"Copy to Existing Target - Abort", CopyMoveFileRequest{OnConflict: "abort", SourcePath: sourcePath, TargetPath: targetPath}, http.StatusConflict},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonData, _ := json.Marshal(tt.request)
+			req, _ := http.NewRequest(http.MethodPost, "/api/action/copy", bytes.NewReader(jsonData))
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+		})
+	}
+
+	removeFile(targetPath)
+}
+
+func TestCreateFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		request        CreateFileRequest
+		expectedStatus int
+	}{
+		{"Create New File", CreateFileRequest{Path: newFilePath}, http.StatusCreated},
+		{"Create Existing File", CreateFileRequest{Path: sourcePath}, http.StatusConflict},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonData, _ := json.Marshal(tt.request)
+			req, _ := http.NewRequest(http.MethodPost, "/api/action/create", bytes.NewReader(jsonData))
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+		})
+	}
+}
+
+func TestMoveFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		request        CopyMoveFileRequest
+		expectedStatus int
+	}{
+		{"Move Existing File", CopyMoveFileRequest{OnConflict: "overwrite", SourcePath: sourcePath, TargetPath: targetPath}, http.StatusOK},
+		{"Move Non-Existing Source", CopyMoveFileRequest{OnConflict: "overwrite", SourcePath: invalidPath, TargetPath: targetPath}, http.StatusNotFound},
+		{"Move to Existing Target - Overwrite", CopyMoveFileRequest{OnConflict: "overwrite", SourcePath: sourcePath, TargetPath: targetPath}, http.StatusOK},
+		{"Move to Existing Target - Abort", CopyMoveFileRequest{OnConflict: "abort", SourcePath: sourcePath, TargetPath: targetPath}, http.StatusConflict},
+	}
+
+	for _, tt := range tests {
+		if tt.name == "Move to Existing Target - Overwrite" || tt.name == "Move to Existing Target - Abort" {
+			postUploadFile(sourcePath, gifData)
+			time.Sleep(100 * time.Millisecond)
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			jsonData, _ := json.Marshal(tt.request)
+			req, _ := http.NewRequest(http.MethodPost, "/api/action/move", bytes.NewReader(jsonData))
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+		})
+	}
+
+	removeFile(targetPath)
+}
+
+func TestGetImage(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		query          string
+		expectedStatus int
+	}{
+		{"Get Existing Image", imagePath, "", http.StatusOK},
+		{"Get Non-Existing Image", invalidPath, "", http.StatusNotFound},
+		{"Get Image with Parameters", imagePath, "?w=100&h=100&q=80&f=jpg&a=90&s=fit", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, "/api/image/"+tt.path+tt.query, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+		})
+	}
+}
+
+func TestGetFileMeta(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		expectedStatus int
+	}{
+		{"Get Existing File Meta", metaFilePath, http.StatusOK},
+		{"Get Non-Existing File Meta", invalidPath, http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, "/api/meta/"+tt.path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+		})
+	}
+}

--- a/route/test/file_test.go
+++ b/route/test/file_test.go
@@ -1,0 +1,117 @@
+package test
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vvbbnn00/goflet/config"
+	"github.com/vvbbnn00/goflet/route"
+	"github.com/vvbbnn00/goflet/util"
+)
+
+var (
+	tmpFileName string
+	router      *gin.Engine
+	gifData     = []byte("GIF89a\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff\x00\x00\x00!\xf9\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;")
+	gifLen      = len(gifData)
+)
+
+func init() {
+	config.InitConfig()
+	*config.GofletCfg.JWTConfig.Enabled = false
+	router = route.RegisterRoutes()
+	prepareFileUpload()
+}
+
+func prepareFileUpload() {
+	tmpFileName = "/tmp/" + util.RandomString(16) + ".txt"
+	req, _ := http.NewRequest(http.MethodDelete, "/file"+tmpFileName, nil)
+	router.ServeHTTP(httptest.NewRecorder(), req)
+}
+
+// TestFileUpload tests the file upload functionality
+func TestFileUpload(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		endpoint       string
+		body           []byte
+		contentRange   string
+		contentLength  string
+		expectedStatus int
+		expectedBody   string
+	}{
+		{"Partial Upload Part 1", http.MethodPut, "/upload" + tmpFileName, gifData[:10], "bytes 0-9/" + strconv.Itoa(gifLen), "10", http.StatusAccepted, ""},
+		{"Partial Upload Part 2", http.MethodPut, "/upload" + tmpFileName, gifData[10:], "bytes 10-" + strconv.Itoa(gifLen-1) + "/" + strconv.Itoa(gifLen), strconv.Itoa(gifLen - 10), http.StatusAccepted, ""},
+		{"Complete Upload", http.MethodPost, "/upload" + tmpFileName, nil, "", "", http.StatusCreated, ""},
+		{"Get File", http.MethodGet, "/file" + tmpFileName, nil, "", "", http.StatusOK, string(gifData)},
+		{"Get File Part", http.MethodGet, "/file" + tmpFileName, nil, "bytes=0-9", "10", http.StatusPartialContent, string(gifData[:10])},
+		{"Delete File", http.MethodDelete, "/file" + tmpFileName, nil, "", "", http.StatusNoContent, ""},
+		{"Post File Upload", http.MethodPost, "/file" + tmpFileName, gifData, "", "", http.StatusCreated, ""},
+		{"Get File", http.MethodGet, "/file" + tmpFileName, nil, "", "", http.StatusOK, string(gifData)},
+		{"Delete File", http.MethodDelete, "/file" + tmpFileName, nil, "", "", http.StatusNoContent, ""},
+	}
+
+	for _, tt := range tests {
+		if tt.name == "Post File Upload" {
+			testFilePostUpload(t)
+			time.Sleep(100 * time.Millisecond) // Wait for the file to be written
+			continue
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			var req *http.Request
+			if tt.body != nil {
+				req, _ = http.NewRequest(tt.method, tt.endpoint, bytes.NewReader(tt.body))
+			} else {
+				req, _ = http.NewRequest(tt.method, tt.endpoint, nil)
+			}
+			if tt.contentRange != "" {
+				if tt.method == http.MethodPut {
+					req.Header.Set("Content-Range", tt.contentRange)
+				} else {
+					req.Header.Set("Range", tt.contentRange)
+				}
+			}
+			if tt.contentLength != "" {
+				req.Header.Set("Content-Length", tt.contentLength)
+			}
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			assert.Equal(t, tt.expectedBody, w.Body.String())
+
+			if tt.name == "Complete Upload" {
+				time.Sleep(100 * time.Millisecond) // Wait for the file to be written
+			}
+		})
+	}
+}
+
+func testFilePostUpload(t *testing.T) {
+	w := httptest.NewRecorder()
+	formData := new(bytes.Buffer)
+	writer := multipart.NewWriter(formData)
+	part, _ := writer.CreateFormFile("file", "test.txt")
+	write, err := part.Write(gifData)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	assert.Equal(t, gifLen, write)
+	_ = writer.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, "/file"+tmpFileName, formData)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, "", w.Body.String())
+}


### PR DESCRIPTION
[perf: Limit the size of uploads in one PUT request to prevent excessive memory usage](https://github.com/vvbbnn00/goflet/commit/9582d9a0a4420166d652090914b78b34cf667672) 
[fix: Correct the issue where JWT is still required for verification even when it is set to off](https://github.com/vvbbnn00/goflet/commit/303f0f3a31a21a3534f3cc6d892de9bc13c17a89) 
[test: Add some tests for HTTP API](https://github.com/vvbbnn00/goflet/commit/eba361e1a73801461cc2fa3fe6c12163c52571c9)
[refactor: Change the response code of the create file API to 201](https://github.com/vvbbnn00/goflet/commit/1921a435e5b392d8e29f24772b0c95ac672c3365)